### PR TITLE
Fix: Handle origin in frontend with reverse proxy

### DIFF
--- a/build/helmfile.yaml
+++ b/build/helmfile.yaml
@@ -76,6 +76,7 @@ releases:
     vars:
       PORT: 3000
       ORIGIN: {{ requiredEnv "DEPLOY_HOST" | quote }}
+      REVERSE_PROXY_ENABLED: true
     containerPort: 3000
     ingress:
       host: {{ requiredEnv "DEPLOY_HOST" | quote }}

--- a/frontend/src/entry.express.tsx
+++ b/frontend/src/entry.express.tsx
@@ -35,14 +35,16 @@ const { router, notFound } = createQwikCity({
   render,
   qwikCityPlan,
   manifest,
-  // getOrigin(req) {
-  //   // If deploying under a proxy, you may need to build the origin from the request headers
-  //   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-  //   const protocol = req.headers["x-forwarded-proto"] ?? "http";
-  //   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
-  //   const host = req.headers["x-forwarded-host"] ?? req.headers.host;
-  //   return `${protocol}://${host}`;
-  // }
+  ...(process.env.REVERSE_PROXY_ENABLED ? {
+    getOrigin(req) {
+      // If deploying under a proxy, you may need to build the origin from the request headers
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+      const protocol = req.headers["x-forwarded-proto"] ?? "http";
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+      const host = req.headers["x-forwarded-host"] ?? req.headers.host;
+      return `${protocol}://${host}`;
+    }
+  } : {}),
 });
 
 // Create the express server


### PR DESCRIPTION
The frontend currently fails to construct a valid URL from the origin, as the protocol is missing from the generated origin.
This fix adds an env-flag `REVERSE_PROXY_ENABLED`, which enables the template-code for extracting the origin from passed `X-Forwarded`-headers, and sets it in the deployment.

This is needed because the deployment in k8s is behind a reverse proxy for ingress-handling.