### PR TITLE
Hotfix: Swagger UI /v3/api-docs/swagger-config path

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -17,5 +17,7 @@ springdoc:
     url: "/api/spec.yaml" # served path to spec.yaml
     path: "/api"
   enable-default-api-docs: false
+  api-docs:
+    path: "/api/v3/api-docs" # (=> /api/v3/api-docs/swagger-config)
   webjars:
     prefix: "/api"


### PR DESCRIPTION
Change path from
`/v3/api-docs/**`
to
`/api/v3/api-docs/**`