### PR TITLE
feat(api): adjust api to represent answer scheme

### DIFF
--- a/api/spec.yaml
+++ b/api/spec.yaml
@@ -764,17 +764,11 @@ components:
           description: The Id for a tag to be used for the filter.
     Answers:
       type: array
+      description: Contains all IDs that have been answered positively.
       items:
-        type: object
-        properties:
-          questionId:
-            type: integer
-            example: 1
-            description: Unique ID of the question.
-          answer:
-            type: string
-            enum: [pos, neu, neg]
-            description: The given answer, one of positive, neutral, negative.
+        type: integer
+        example: 1
+        description: Unique ID of the question.
     GeoJsonOrganizations:
       type: object
 

--- a/backend/src/main/kotlin/saplingsquad/api/service/QuestionsApiService.kt
+++ b/backend/src/main/kotlin/saplingsquad/api/service/QuestionsApiService.kt
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import saplingsquad.api.QuestionsApiDelegate
-import saplingsquad.api.models.AnswersInner
 import saplingsquad.api.models.Question
 import saplingsquad.config.AppConfig
 import saplingsquad.persistence.QuestionsRepository
@@ -32,6 +31,10 @@ class QuestionsApiService(private val repository: QuestionsRepository, @Autowire
             .map { it.tableEntityToApi() }
             .asHttpOkResponse()
 
+    override suspend fun postAnswers(userToken: String, answers: List<Int>?): ResponseEntity<Unit> {
+        TODO("Not yet implemented")
+    }
+
     /**
      * API Endpoint to get a single question
      */
@@ -40,10 +43,6 @@ class QuestionsApiService(private val repository: QuestionsRepository, @Autowire
         return entity
             .tableEntityToApi()
             .asHttpOkResponse()
-    }
-
-    override suspend fun postAnswers(userToken: String, answers: List<AnswersInner>?): ResponseEntity<Unit> {
-        TODO("Not yet implemented")
     }
 
     override fun getFilters(userToken: String): ResponseEntity<Flow<Int>> {


### PR DESCRIPTION
There are only two possible answers to questions, this means we can omit the enum and send a list of IDs. This list only contains positive/ highlighted/ choosen IDs.

Closes #67 