### PR TITLE
Fix GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore SQL files containing the region data in the backend
+backend/src/main/resources/db/static-data/0014/*.sql linguist-vendored


### PR DESCRIPTION
At the moment GitHub's language stats show > 97% PLpgSQL in the repository.
Fix these stats by marking the large SQL files containing the region geometry as
`linguist-vendored` to exclude them from the stats calculation.
See also https://github.com/github-linguist/linguist/blob/main/docs/overrides.md