### PR TITLE
Fix docker build of frontend

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,44 @@
+## .gitignore
+
+# Build
+/dist
+/lib
+/lib-types
+/server
+
+# Development
+node_modules
+.env
+*.local
+
+# Cache
+.cache
+.mf
+.rollup.cache
+tsconfig.tsbuildinfo
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+# Editor
+.vscode/*
+!.vscode/launch.json
+!.vscode/*.code-snippets
+
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Yarn
+.yarn/*
+!.yarn/releases

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,9 +13,10 @@ FROM node:22-alpine AS build
 
 WORKDIR /build
 
-COPY --from=cache /cache/node_modules ./node_modules
+COPY --from=cache /cache/node_modules ./frontend/node_modules
 
-COPY ./ ./
+COPY ./api ./api
+COPY ./frontend ./frontend
 
 WORKDIR /build/frontend
 


### PR DESCRIPTION
Frontend would previously build, but crash when running.

##### Changes

- Fix path of `node_modules` copy from cache in `Dockerfile`
- Only copy required files
- Add `.dockerignore` (e.g., for `node_modules`)