### PR TITLE
Backend: Remove `null`-values in responses by default

### DIFF
--- a/backend/src/main/kotlin/saplingsquad/config/WebFluxConfig.kt
+++ b/backend/src/main/kotlin/saplingsquad/config/WebFluxConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.http.codec.ServerCodecConfigurer
 import org.springframework.util.MimeType
 import org.springframework.util.MimeTypeUtils
 import org.springframework.web.reactive.config.CorsRegistry
-import org.springframework.web.reactive.config.EnableWebFlux
 import org.springframework.web.reactive.config.ResourceHandlerRegistry
 import org.springframework.web.reactive.config.WebFluxConfigurer
 import reactor.core.publisher.Flux
@@ -21,7 +20,6 @@ import reactor.core.publisher.Mono
 /**
  * Spring configuration for various settings of Spring webflux
  */
-@EnableWebFlux
 @Configuration
 class WebFluxConfig(
     /** This Configuration depends on some custom configuration properties*/

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -35,6 +35,9 @@ spring:
             issuer-uri: ${appconfig.oauth2.orgas-issuer.issuer-uri}
       # END only for dev purposes
 
+  jackson:
+    default-property-inclusion: non_null
+
 appconfig:
   openapi:
     spec: "static/api/spec.yaml" # local path to spec.yaml


### PR DESCRIPTION
Adheres to API spec, as we set properties to not required, but they are still non-nullable (See #108).
Removed `@EnableWebFlux`-annotation to let spring boot automatically configure from `application.yaml` and the other sources (I think we want that).

Fixes #108.