### PR TITLE
Fix Backend: Adapt database schema to api spec

### DIFF
--- a/backend/src/main/resources/db/changelog/0021-fix-orga-nullability.sql
+++ b/backend/src/main/resources/db/changelog/0021-fix-orga-nullability.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+--changeset 0021:1
+alter table organization
+    alter founding_year drop not null,
+    alter website_url set not null;

--- a/backend/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/backend/src/main/resources/db/changelog/db.changelog-master.xml
@@ -33,5 +33,6 @@
     <include file="classpath:db/changelog/0018-fix-coordinates-range.sql"/>
     <include file="classpath:db/changelog/0019-create-region-views.sql"/>
     <include file="classpath:db/changelog/0020-org-proj-add-regionname.sql"/>
+    <include file="classpath:db/changelog/0021-fix-orga-nullability.sql"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
In the API spec, organization founding year is non-required, but in database it is non-nullable.
In the API spec, organization website URL is required, but in database it is nullable.