### PR TITLE
Allow setting bookmarks

### DIFF
--- a/frontend/src/api/bookmarks.ts
+++ b/frontend/src/api/bookmarks.ts
@@ -1,0 +1,128 @@
+import type { QRL, Signal } from "@builder.io/qwik";
+import { $, useSignal, useTask$ } from "@builder.io/qwik";
+import { useAuthHeader } from "~/auth/useauthheader";
+import {
+  deleteOrganizationBookmark,
+  deleteProjectBookmark,
+  getOrganizationBookmarks,
+  getProjectBookmarks,
+  postOrganizationBookmark,
+  postProjectBookmark,
+} from "./api_methods.gen";
+
+/**
+ * Uses the bookmark state of a project.
+ *
+ * @param id id of the project
+ * @param externalSignal An optional external signal to use instead of creating one
+ * @returns A signal that contains whether the project is bookmarked. Updates to the signal will be sent to the server.
+ */
+export const useProjectBookmark = (
+  id: number,
+  externalSignal?: Signal<boolean | undefined>,
+) => {
+  return useBookmark(
+    id,
+    {
+      get$: $((headers) =>
+        getProjectBookmarks(headers).then((r) =>
+          r.status === 200 ? r.body : undefined,
+        ),
+      ),
+      create$: $((headers, id) => postProjectBookmark(headers, { id: id })),
+      delete$: $((headers, id) => deleteProjectBookmark(headers, { id: id })),
+    },
+    externalSignal,
+  );
+};
+
+/**
+ * Uses the bookmark state of an organization.
+ *
+ * @param id id of the organization
+ * @param externalSignal An optional external signal to use instead of creating one
+ * @returns A signal that contains whether the organization is bookmarked. Updates to the signal will be sent to the server.
+ */
+export const useOrganizationBookmark = (
+  id: number,
+  externalSignal?: Signal<boolean | undefined>,
+) => {
+  return useBookmark(
+    id,
+    {
+      get$: $((headers) =>
+        getOrganizationBookmarks(headers).then((r) =>
+          r.status === 200 ? r.body : undefined,
+        ),
+      ),
+      create$: $((headers, id) =>
+        postOrganizationBookmark(headers, { id: id }),
+      ),
+      delete$: $((headers, id) =>
+        deleteOrganizationBookmark(headers, { id: id }),
+      ),
+    },
+    externalSignal,
+  );
+};
+
+/**
+ * Uses the bookmark state of something.
+ *
+ * @param id Id of the entity.
+ * @param param1 The functions to get/create/delete a bookmark
+ * @param externalSignal An optional external signal to use instead of creating one
+ * @returns A signal that contains whether the entity is bookmarked. Updates to the signal will be sent to the server.
+ */
+export const useBookmark = (
+  id: number,
+  {
+    get$,
+    create$,
+    delete$,
+  }: {
+    get$: QRL<
+      (authHeaders: Record<string, string>) => PromiseLike<number[] | undefined>
+    >;
+    create$: QRL<(authHeaders: Record<string, string>, id: number) => unknown>;
+    delete$: QRL<(authHeaders: Record<string, string>, id: number) => unknown>;
+  },
+  externalSignal?: Signal<boolean | undefined>,
+) => {
+  const authHeaders = useAuthHeader();
+  const publicBookmarkedNewSignal = useSignal<boolean>(); // new signal if none provided
+  // state as modified by the client
+  const publicBookmarked = externalSignal ?? publicBookmarkedNewSignal;
+  // state as last set
+  const internalBookmarked = useSignal<boolean>();
+
+  // init
+  useTask$(async () => {
+    if (!authHeaders.value) return;
+    const bookmarks = await get$(authHeaders.value);
+    if (bookmarks !== undefined) {
+      // received some bookmarks
+      const isBookmarked = bookmarks.includes(id);
+      internalBookmarked.value = isBookmarked;
+      publicBookmarked.value = isBookmarked;
+    }
+  });
+
+  // updates
+  useTask$(({ track }) => {
+    const isBookmarked = internalBookmarked.value;
+    const shouldBeBookmarked = track(publicBookmarked);
+    const headers = authHeaders.value;
+
+    if (!headers) return; // not logged in
+    if (isBookmarked === shouldBeBookmarked) return; // no change
+
+    if (shouldBeBookmarked) create$(headers, id);
+    else delete$(headers, id);
+
+    // update internal state
+    internalBookmarked.value = shouldBeBookmarked;
+  });
+
+  return publicBookmarked;
+};

--- a/frontend/src/components/bookmark.tsx
+++ b/frontend/src/components/bookmark.tsx
@@ -1,0 +1,33 @@
+import type { QRL } from "@builder.io/qwik";
+import { component$ } from "@builder.io/qwik";
+import {
+  HiBookmarkOutline,
+  HiBookmarkSlashOutline,
+} from "@qwikest/icons/heroicons";
+
+export type BookmarkProps = {
+  /**
+   * Whether this card is currently bookmarked
+   */
+  bookmarked: boolean;
+  /**
+   * Handler to execute when the bookmark-button is clicked
+   */
+  onSetBookmarked$: QRL<(newValue: boolean) => unknown>;
+};
+
+/**
+ * Shows a button that allows to bookmark something.
+ * Uses the passed state and listener.
+ */
+export const BookmarkButton = component$(
+  ({ bookmarked, onSetBookmarked$ }: BookmarkProps) => (
+    <button onClick$={() => onSetBookmarked$(!bookmarked)}>
+      {bookmarked ? (
+        <HiBookmarkSlashOutline class="h-7 w-7" />
+      ) : (
+        <HiBookmarkOutline class="h-7 w-7" />
+      )}
+    </button>
+  ),
+);

--- a/frontend/src/components/info/info_card.tsx
+++ b/frontend/src/components/info/info_card.tsx
@@ -6,6 +6,8 @@ import { HiArrowLeftOutline, HiXMarkOutline } from "@qwikest/icons/heroicons";
 import { useGetTags } from "~/api/api_hooks.gen";
 import { toMapping } from "~/api/tags";
 import { isNumberArray } from "~/utils";
+import type { BookmarkProps } from "../bookmark";
+import { BookmarkButton } from "../bookmark";
 import type { LinkTarget } from "../link_button";
 import { IconLinkButton, LinkButton } from "../link_button";
 import { Div } from "../div";
@@ -32,6 +34,8 @@ export const InfoCard = component$(
     aside = false,
     onClose,
     onBack,
+    bookmarked,
+    onSetBookmarked$,
   }: {
     /**
      * Name of the entity
@@ -70,7 +74,7 @@ export const InfoCard = component$(
      * Optionally show a back-button. See {@link LinkTarget}.
      */
     onBack?: LinkTarget;
-  }) => {
+  } & Partial<BookmarkProps>) => {
     return (
       <article class="card relative w-full bg-base-100 shadow-xl">
         {/* Location Preview */}
@@ -101,7 +105,16 @@ export const InfoCard = component$(
             </div>
             <div class="flex min-w-64 shrink grow basis-64 flex-col justify-around">
               {/* Name */}
-              <h2 class="card-title text-3xl">{name}</h2>
+              <h2 class="card-title flex flex-row items-center gap-x-2 text-3xl">
+                {name}
+                {/* Bookmark-Button */}
+                {bookmarked !== undefined && (
+                  <BookmarkButton
+                    bookmarked={bookmarked}
+                    onSetBookmarked$={onSetBookmarked$ ?? $(() => {})}
+                  />
+                )}
+              </h2>
               <div class="flex w-full flex-row flex-wrap items-center gap-4">
                 {/* Properties */}
                 <Slot name="properties" />

--- a/frontend/src/components/info/organization.tsx
+++ b/frontend/src/components/info/organization.tsx
@@ -11,6 +11,7 @@ import type { MaybeSignal } from "~/api/api";
 import { useGetOrganizationById } from "~/api/api_hooks.gen";
 import { formatNumber } from "~/utils";
 import { ApiRequest } from "../api";
+import type { BookmarkProps } from "../bookmark";
 import { LinkButton, type LinkTarget } from "../link_button";
 import type { ApiCoordinates, Coordinates } from "../map";
 import { ActionButton, IconProperty, InfoCard } from "./info_card";
@@ -66,7 +67,7 @@ type OrganizationCardProps = {
    * Optionally show a back-button. See {@link LinkTarget}.
    */
   onProject$?: QRL<(id: number) => unknown>;
-};
+} & Partial<BookmarkProps>;
 
 /**
  * Show information about an organization.
@@ -90,6 +91,8 @@ const OrganizationCard = component$(
     onClose,
     onBack,
     onProject$,
+    bookmarked,
+    onSetBookmarked$,
   }: Organization & OrganizationCardProps) => {
     return (
       <InfoCard
@@ -102,6 +105,8 @@ const OrganizationCard = component$(
         aside={projects.length > 0}
         onClose={onClose}
         onBack={onBack}
+        bookmarked={bookmarked}
+        onSetBookmarked$={onSetBookmarked$}
       >
         {/* Properties */}
         <IconProperty

--- a/frontend/src/components/info/project.tsx
+++ b/frontend/src/components/info/project.tsx
@@ -12,6 +12,7 @@ import { useGetProjectById } from "~/api/api_hooks.gen";
 import { formatDateRange, limitText } from "~/utils";
 import { ApiRequest } from "../api";
 import { Avatar } from "../avatar";
+import type { BookmarkProps } from "../bookmark";
 import type { LinkTarget } from "../link_button";
 import type { ApiCoordinates, Coordinates } from "../map";
 import { ActionButton, IconProperty, InfoCard } from "./info_card";
@@ -77,7 +78,7 @@ type ProjectCardProps = {
    * Optionally show a back-button. See {@link LinkTarget}.
    */
   onBack?: LinkTarget;
-};
+} & Partial<BookmarkProps>;
 
 /**
  * Show information about a {@link Project}.
@@ -101,6 +102,8 @@ const ProjectCard = component$(
     onShowOrganization$,
     onClose,
     onBack,
+    bookmarked,
+    onSetBookmarked$,
   }: Project & ProjectCardProps) => {
     return (
       <InfoCard
@@ -112,6 +115,8 @@ const ProjectCard = component$(
         icon={iconUrl}
         onClose={onClose}
         onBack={onBack}
+        bookmarked={bookmarked}
+        onSetBookmarked$={onSetBookmarked$}
       >
         {/* Properties */}
         <IconProperty

--- a/frontend/src/routes/organization/[id]/index.tsx
+++ b/frontend/src/routes/organization/[id]/index.tsx
@@ -1,10 +1,16 @@
-import { component$ } from "@builder.io/qwik";
+import { $, component$ } from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
+import { useOrganizationBookmark } from "~/api/bookmarks";
 import { OrganizationInfo } from "~/components/info/organization";
 import { InfoPage } from "~/views/info_page";
 
 export default component$(() => {
-  return <InfoPage InfoComponent={OrganizationInfo} />;
+  return (
+    <InfoPage
+      InfoComponent={OrganizationInfo}
+      bookmarkHook$={$(useOrganizationBookmark)}
+    />
+  );
 });
 
 export const head: DocumentHead = {

--- a/frontend/src/routes/project/[id]/index.tsx
+++ b/frontend/src/routes/project/[id]/index.tsx
@@ -1,10 +1,16 @@
-import { component$ } from "@builder.io/qwik";
-import { DocumentHead } from "@builder.io/qwik-city";
+import { $, component$ } from "@builder.io/qwik";
+import type { DocumentHead } from "@builder.io/qwik-city";
+import { useProjectBookmark } from "~/api/bookmarks";
 import { ProjectInfo } from "~/components/info/project";
 import { InfoPage } from "~/views/info_page";
 
 export default component$(() => {
-  return <InfoPage InfoComponent={ProjectInfo} />;
+  return (
+    <InfoPage
+      InfoComponent={ProjectInfo}
+      bookmarkHook$={$(useProjectBookmark)}
+    />
+  );
 });
 
 export const head: DocumentHead = {

--- a/frontend/src/views/info_page.tsx
+++ b/frontend/src/views/info_page.tsx
@@ -1,7 +1,8 @@
-import type { Component } from "@builder.io/qwik";
-import { component$ } from "@builder.io/qwik";
+import type { Component, QRL, Signal } from "@builder.io/qwik";
+import { component$, useSignal } from "@builder.io/qwik";
 import { useLocation } from "@builder.io/qwik-city";
 import { HiExclamationCircleOutline } from "@qwikest/icons/heroicons";
+import type { BookmarkProps } from "~/components/bookmark";
 
 /**
  * A component that displays the `InfoComponent` on a fullscreen-page.
@@ -9,14 +10,32 @@ import { HiExclamationCircleOutline } from "@qwikest/icons/heroicons";
  * and passes it to the `load`-prop of the `InfoComponent`.
  */
 export const InfoPage = component$(
-  ({ InfoComponent }: { InfoComponent: Component<{ load: number }> }) => {
+  ({
+    InfoComponent,
+    bookmarkHook$: useBookmark$,
+  }: {
+    InfoComponent: Component<{ load: number } & Partial<BookmarkProps>>;
+    bookmarkHook$: QRL<
+      (
+        id: number,
+        signal: Signal<boolean | undefined>,
+      ) => Signal<boolean | undefined>
+    >;
+  }) => {
     const location = useLocation();
     const id = Number(location.params.id);
     const validId = !isNaN(id) && Number.isInteger(id);
+    const bookmarked = useSignal<boolean>();
+    useBookmark$(id, bookmarked);
+
     return (
       <div class="flex min-h-full w-full items-start justify-center overflow-y-auto p-2 sm:p-4 md:p-8 xl:px-32 2xl:px-48">
         {validId ? (
-          <InfoComponent load={id} />
+          <InfoComponent
+            load={id}
+            bookmarked={bookmarked.value}
+            onSetBookmarked$={(newValue) => (bookmarked.value = newValue)}
+          />
         ) : (
           <div
             role="alert"


### PR DESCRIPTION
Info-cards now display the current state of bookmark to the user.
The full-page-infos can already get and update the state of a bookmark.
When using this component, one can manually set the state of bookmarked and listen for updates.
For example-implementation, see `organization`/`project`-pages.

![A bookmarked project](https://github.com/user-attachments/assets/88aba775-712a-4eb6-9b20-c1b367f56e2a)

Closes #13.